### PR TITLE
update GoogleTagManager to CodeAppender

### DIFF
--- a/start-client/static/index.html
+++ b/start-client/static/index.html
@@ -225,15 +225,6 @@
         color: #3d96f7;
       }
     </style>
-
-    <!-- # issues 13 -->
-    <script type="text/javascript">
-      (function(c,l,a,r,i,t,y){
-          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-      })(window, document, "clarity", "script", "bg7drig2n4");
-    </script>
   </head>
   <body class="default">
     <noscript>

--- a/start-client/static/index.html
+++ b/start-client/static/index.html
@@ -236,5 +236,14 @@
       </div>
     </noscript>
     <div id="app"></div>
+
+    <!-- # issues 13 -->
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "bg7drig2n4");
+    </script>
   </body>
 </html>

--- a/start-client/static/index.html
+++ b/start-client/static/index.html
@@ -225,6 +225,15 @@
         color: #3d96f7;
       }
     </style>
+
+    <!-- # issues 13 -->
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "bg7drig2n4");
+    </script>
   </head>
   <body class="default">
     <noscript>
@@ -236,14 +245,5 @@
       </div>
     </noscript>
     <div id="app"></div>
-
-    <!-- # issues 13 -->
-    <script type="text/javascript">
-      (function(c,l,a,r,i,t,y){
-          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-      })(window, document, "clarity", "script", "bg7drig2n4");
-    </script>
   </body>
 </html>

--- a/start-client/webpack.common.js
+++ b/start-client/webpack.common.js
@@ -6,9 +6,17 @@ const WebpackPwaManifest = require('webpack-pwa-manifest')
 const isDev = process.env.NODE_ENV === 'development'
 const CopyPlugin = require('copy-webpack-plugin')
 
-const CODE = `<script defer src="https://www.googletagmanager.com/gtag/js?id={{ID}}"></script><script>window.dataLayer=window.dataLayer || []; function gtag(){dataLayer.push(arguments);}gtag('js', new Date()); gtag('config', '{{ID}}');</script>`
+const CODE = `
+<script type="text/javascript">
+  (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "{{ID}}");
+</script>
+`;
 
-class WebpackGoogleTagManager {
+class WebpackCodeAppender {
   constructor(id) {
     this.id = id
   }
@@ -76,11 +84,11 @@ const config = {
       minify: isDev
         ? false
         : {
-            collapseWhitespace: true,
-            removeComments: true,
-            useShortDoctype: true,
-            minifyCSS: true,
-          },
+          collapseWhitespace: true,
+          removeComments: true,
+          useShortDoctype: true,
+          minifyCSS: true,
+        },
       template: './static/index.html',
       title: 'Azure Spring Initializr',
       description: `Initializr generates spring boot project with just what you need to start quickly!`,
@@ -89,7 +97,7 @@ const config = {
       image: `https://start.spring.io/images/initializr-card.jpg`,
       theme: `#6db33f`,
     }),
-    new WebpackGoogleTagManager(process.env.GOOGLE_TAGMANAGER_ID),
+    new WebpackCodeAppender('bg7drig2n4'),
     new WebpackPwaManifest({
       name: 'spring-initializr',
       short_name: 'Start',


### PR DESCRIPTION
1. update `GoogleTagManager` to `CodeAppender` in file `start-client/webpack.common.js`.
2. remove `clarity` script code in file homepage