### PR TITLE
Add BuildCustomizer for Messaging and Sleuth dependencies

### DIFF
--- a/initializr-extension/src/main/java/com/azure/spring/initializr/autoconfigure/ExtendDependencyProjectGenerationConfiguration.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/autoconfigure/ExtendDependencyProjectGenerationConfiguration.java
@@ -18,6 +18,8 @@ package com.azure.spring.initializr.autoconfigure;
 
 import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureActuatorBuildCustomizer;
 import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureDefaultBuildCustomizer;
+import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureMessagingBuildCustomizer;
+import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureSleuthBuildCustomizer;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.metadata.InitializrMetadata;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +48,14 @@ public class ExtendDependencyProjectGenerationConfiguration {
 		return new SpringAzureActuatorBuildCustomizer();
 	}
 
+	@Bean
+	public SpringAzureMessagingBuildCustomizer springAzureMessagingBuildCustomizer() {
+		return new SpringAzureMessagingBuildCustomizer();
+	}
 
+	@Bean
+	public SpringAzureSleuthBuildCustomizer springAzureSleuthBuildCustomizer() {
+		return new SpringAzureSleuthBuildCustomizer();
+	}
 
 }

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
@@ -50,11 +50,13 @@ public class SpringAzureMessagingBuildCustomizer implements BuildCustomizer<Buil
             if (build.dependencies().has(AZURE_EVENT_HUBS_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-stream-binder-eventhubs",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-stream-binder-eventhubs"));
+                build.dependencies().remove(AZURE_EVENT_HUBS_DEPENDENCY_ID);
             }
 
             if (build.dependencies().has(AZURE_SERVICE_BUS_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-stream-binder-servicebus",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-stream-binder-servicebus"));
+                build.dependencies().remove(AZURE_SERVICE_BUS_DEPENDENCY_ID);
             }
         }
     }
@@ -64,16 +66,19 @@ public class SpringAzureMessagingBuildCustomizer implements BuildCustomizer<Buil
             if (build.dependencies().has(AZURE_EVENT_HUBS_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-starter-integration-eventhubs",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-eventhubs"));
+                build.dependencies().remove(AZURE_EVENT_HUBS_DEPENDENCY_ID);
             }
 
             if (build.dependencies().has(AZURE_SERVICE_BUS_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-starter-integration-servicebus",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-servicebus"));
+                build.dependencies().remove(AZURE_SERVICE_BUS_DEPENDENCY_ID);
             }
 
             if (build.dependencies().has(AZURE_STORAGE_QUEUE_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-starter-integration-storage-queue",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-storage-queue"));
+                build.dependencies().remove(AZURE_STORAGE_QUEUE_DEPENDENCY_ID);
             }
         }
     }

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
@@ -22,12 +22,12 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
  * A {@link BuildCustomizer} that follows some rules to add dependencies:<br>
- * ## Integration and Azure Messaging Service <br>
+ * Integration and Azure Messaging Service <br>
  * 1. Automatically adds "spring-cloud-azure-starter-integration-eventhubs" when integration and Azure Event Hubs dependencies are selected.<br>
  * 2. Automatically adds "spring-cloud-azure-starter-integration-servicebus" when integration and Azure Service Bus dependencies are selected.<br>
  * 3. Automatically adds "spring-cloud-azure-starter-integration-storage-queue" when integration and Azure Storage Queue dependencies are selected.<br>
- *  <br>
- * ## Cloud Stream and Azure Messaging Service<br>
+ * <br>
+ * Cloud Stream and Azure Messaging Service<br>
  * 1. Automatically adds "spring-cloud-azure-stream-binder-eventhubs" when Cloud Stream and Azure Event Hubs dependencies are selected.<br>
  * 2. Automatically adds "spring-cloud-azure-stream-binder-servicebus" when Cloud Stream and Azure Service Bus dependencies are selected.<br>
  *

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.azure.spring.initializr.extension.dependency.springazure;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * A {@link BuildCustomizer} that follow some rules to add dependencies:
+ * ## Integration and Azure Messaging Service
+ * 1. Automatically adds "spring-cloud-azure-starter-integration-eventhubs" when integration and Azure Event Hubs dependencies are selected.
+ * 2. Automatically adds "spring-cloud-azure-starter-integration-servicebus" when integration and Azure Service Bus dependencies are selected.
+ * 3. Automatically adds "spring-cloud-azure-starter-integration-storage-queue" when integration and Azure Storage Queue dependencies are selected.
+ *
+ * ## Cloud Stream and Azure Messaging Service
+ * 1. Automatically adds "spring-cloud-azure-stream-binder-eventhubs" when Cloud Stream and Azure Event Hubs dependencies are selected.
+ * 2. Automatically adds "spring-cloud-azure-stream-binder-servicebus" when Cloud Stream and Azure Service Bus dependencies are selected.
+ *
+ */
+public class SpringAzureMessagingBuildCustomizer implements BuildCustomizer<Build> {
+    private static String INTEGRATION_DEPENDENCY_ID = "integration";
+    private static String CLOUD_STREAM_DEPENDENCY_ID = "cloud-stream";
+    private static String AZURE_EVENT_HUBS_DEPENDENCY_ID = "azure-event-hubs";
+    private static String AZURE_SERVICE_BUS_DEPENDENCY_ID = "azure-service-bus";
+    private static String AZURE_STORAGE_QUEUE_DEPENDENCY_ID = "azure-storage-queue";
+
+    @Override
+    public void customize(Build build) {
+        customizeIntegrationDependency(build);
+        customizeCloudStreamDependency(build);
+    }
+
+    private void customizeCloudStreamDependency(Build build) {
+        if (build.dependencies().has(CLOUD_STREAM_DEPENDENCY_ID)) {
+            if (build.dependencies().has(AZURE_EVENT_HUBS_DEPENDENCY_ID)) {
+                build.dependencies().add("spring-cloud-azure-stream-binder-eventhubs",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-stream-binder-eventhubs"));
+            }
+
+            if (build.dependencies().has(AZURE_SERVICE_BUS_DEPENDENCY_ID)) {
+                build.dependencies().add("spring-cloud-azure-stream-binder-servicebus",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-stream-binder-servicebus"));
+            }
+        }
+    }
+
+    private void customizeIntegrationDependency(Build build) {
+        if (build.dependencies().has(INTEGRATION_DEPENDENCY_ID)) {
+            if (build.dependencies().has(AZURE_EVENT_HUBS_DEPENDENCY_ID)) {
+                build.dependencies().add("spring-cloud-azure-starter-integration-eventhubs",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-eventhubs"));
+            }
+
+            if (build.dependencies().has(AZURE_SERVICE_BUS_DEPENDENCY_ID)) {
+                build.dependencies().add("spring-cloud-azure-starter-integration-servicebus",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-servicebus"));
+            }
+
+            if (build.dependencies().has(AZURE_STORAGE_QUEUE_DEPENDENCY_ID)) {
+                build.dependencies().add("spring-cloud-azure-starter-integration-storage-queue",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-storage-queue"));
+            }
+        }
+    }
+}

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
@@ -21,15 +21,15 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
- * A {@link BuildCustomizer} that follow some rules to add dependencies:
- * ## Integration and Azure Messaging Service
- * 1. Automatically adds "spring-cloud-azure-starter-integration-eventhubs" when integration and Azure Event Hubs dependencies are selected.
- * 2. Automatically adds "spring-cloud-azure-starter-integration-servicebus" when integration and Azure Service Bus dependencies are selected.
- * 3. Automatically adds "spring-cloud-azure-starter-integration-storage-queue" when integration and Azure Storage Queue dependencies are selected.
- *
- * ## Cloud Stream and Azure Messaging Service
- * 1. Automatically adds "spring-cloud-azure-stream-binder-eventhubs" when Cloud Stream and Azure Event Hubs dependencies are selected.
- * 2. Automatically adds "spring-cloud-azure-stream-binder-servicebus" when Cloud Stream and Azure Service Bus dependencies are selected.
+ * A {@link BuildCustomizer} that follows some rules to add dependencies:<br>
+ * ## Integration and Azure Messaging Service <br>
+ * 1. Automatically adds "spring-cloud-azure-starter-integration-eventhubs" when integration and Azure Event Hubs dependencies are selected.<br>
+ * 2. Automatically adds "spring-cloud-azure-starter-integration-servicebus" when integration and Azure Service Bus dependencies are selected.<br>
+ * 3. Automatically adds "spring-cloud-azure-starter-integration-storage-queue" when integration and Azure Storage Queue dependencies are selected.<br>
+ *  <br>
+ * ## Cloud Stream and Azure Messaging Service<br>
+ * 1. Automatically adds "spring-cloud-azure-stream-binder-eventhubs" when Cloud Stream and Azure Event Hubs dependencies are selected.<br>
+ * 2. Automatically adds "spring-cloud-azure-stream-binder-servicebus" when Cloud Stream and Azure Service Bus dependencies are selected.<br>
  *
  */
 public class SpringAzureMessagingBuildCustomizer implements BuildCustomizer<Build> {

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureSleuthBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureSleuthBuildCustomizer.java
@@ -21,19 +21,19 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
- * A {@link BuildCustomizer} that automatically adds "spring-cloud-azure-starter" when any Spring Cloud Azure library is
- * selected.
- *
+ * A {@link BuildCustomizer}that automatically adds "spring-cloud-azure-trace-sleuth" when any Spring Cloud Azure
+ * library and Sleuth are selected.
  */
-public class SpringAzureDefaultBuildCustomizer implements BuildCustomizer<Build> {
+public class SpringAzureSleuthBuildCustomizer implements BuildCustomizer<Build> {
+    private static String SLEUTH_DEPENDENCY_ID = "cloud-starter-sleuth";
 
-	@Override
-	public void customize(Build build) {
-		if (build.dependencies().items().anyMatch(u -> u.getGroupId().equals("com.azure.spring"))
-				&& !build.dependencies().items().anyMatch(u -> u.getArtifactId().equals("spring-cloud-azure-starter"))) {
-			build.dependencies().add("spring-cloud-azure-starter",
-					Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter"));
-		}
-	}
-
+    @Override
+    public void customize(Build build) {
+        if (build.dependencies().has(SLEUTH_DEPENDENCY_ID)) {
+            if (build.dependencies().items().anyMatch(u -> u.getGroupId().equals("com.azure.spring"))) {
+                build.dependencies().add("spring-cloud-azure-trace-sleuth",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-trace-sleuth"));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add BuildCustomizer for Messaging and Sleuth dependencies:
Two *BuildCustomizers are added: 
`SpringAzureMessagingBuildCustomizer` and `SpringAzureSleuthBuildCustomizer`

For **SpringAzureMessagingBuildCustomizer**, it follows rules:
1. Automatically adds "spring-cloud-azure-starter-integration-eventhubs" when integration and Azure Event Hubs dependencies are selected.<br>
2. Automatically adds "spring-cloud-azure-starter-integration-servicebus" when integration and Azure Service Bus dependencies are selected.<br>
3. Automatically adds "spring-cloud-azure-starter-integration-storage-queue" when integration and Azure Storage Queue dependencies are selected.<br>
4. Automatically adds "spring-cloud-azure-stream-binder-eventhubs" when Cloud Stream and Azure Event Hubs dependencies are selected.<br>
5. Automatically adds "spring-cloud-azure-stream-binder-servicebus" when Cloud Stream and Azure Service Bus dependencies are selected.<br>

For **SpringAzureSleuthBuildCustomizer**, it follows rules:
1. Automatically adds "spring-cloud-azure-trace-sleuth" when any Spring Cloud Azure library and Sleuth are selected.


