### PR TITLE
Add spring-cloud-azure-native-configuration build customizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Source code of "Web" module is based on [Spring Initializr's this commit](https:
 
 ## Continues Deployment
 
-[The GitHub Action](https://github.com/Azure/azure-spring-initializr/blob/main/.github/workflows/deploy-to-azure-spring-cloud.yml) deploys every change to [Azure Spring Cloud](https://azure.microsoft.com/en-us/services/spring-cloud/), the live instance of **Azure Spring Initializr** can be accessed [here](https://azure-spring-initializr-dev-azure-spring-initializr.azuremicroservices.io)
+[The GitHub Action](https://github.com/Azure/azure-spring-initializr/blob/main/.github/workflows/deploy-to-azure-spring-cloud.yml) deploys every change to [Azure Spring Cloud](https://azure.microsoft.com/en-us/services/spring-cloud/), the live instance of **Azure Spring Initializr** can be accessed [here](https://aka.ms/spring/start)

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/autoconfigure/ExtendDependencyProjectGenerationConfiguration.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/autoconfigure/ExtendDependencyProjectGenerationConfiguration.java
@@ -19,7 +19,13 @@ package com.azure.spring.initializr.autoconfigure;
 import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureActuatorBuildCustomizer;
 import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureDefaultBuildCustomizer;
 import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureMessagingBuildCustomizer;
+import com.azure.spring.initializr.extension.dependency.springazure.SpringCloudAzureNativeGradleBuildCustomizer;
+import com.azure.spring.initializr.extension.dependency.springazure.SpringCloudAzureNativeMavenBuildCustomizer;
 import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureSleuthBuildCustomizer;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
+import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
+import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.metadata.InitializrMetadata;
 import org.springframework.context.annotation.Bean;
@@ -58,4 +64,15 @@ public class ExtendDependencyProjectGenerationConfiguration {
 		return new SpringAzureSleuthBuildCustomizer();
 	}
 
+    @Bean
+    @ConditionalOnBuildSystem(MavenBuildSystem.ID)
+    public SpringCloudAzureNativeMavenBuildCustomizer springCloudAzureNativeMavenBuildCustomizer(ProjectDescription description) {
+        return new SpringCloudAzureNativeMavenBuildCustomizer(description.getPlatformVersion());
+    }
+
+    @Bean
+    @ConditionalOnBuildSystem(GradleBuildSystem.ID)
+    public SpringCloudAzureNativeGradleBuildCustomizer springCloudAzureNativeGradleBuildCustomizer(ProjectDescription description) {
+        return new SpringCloudAzureNativeGradleBuildCustomizer(description.getPlatformVersion());
+    }
 }

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/autoconfigure/ExtendDependencyProjectGenerationConfiguration.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/autoconfigure/ExtendDependencyProjectGenerationConfiguration.java
@@ -25,6 +25,7 @@ import com.azure.spring.initializr.extension.dependency.springazure.SpringAzureS
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
+import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.metadata.InitializrMetadata;
@@ -50,27 +51,32 @@ public class ExtendDependencyProjectGenerationConfiguration {
 	}
 
 	@Bean
+    @ConditionalOnRequestedDependency("actuator")
 	public SpringAzureActuatorBuildCustomizer springAzureActuatorBuildCustomizer() {
 		return new SpringAzureActuatorBuildCustomizer();
 	}
 
 	@Bean
+    @ConditionalOnRequestedDependency("cloud-stream")
 	public SpringAzureMessagingBuildCustomizer springAzureMessagingBuildCustomizer() {
 		return new SpringAzureMessagingBuildCustomizer();
 	}
 
 	@Bean
+    @ConditionalOnRequestedDependency("cloud-starter-sleuth")
 	public SpringAzureSleuthBuildCustomizer springAzureSleuthBuildCustomizer() {
 		return new SpringAzureSleuthBuildCustomizer();
 	}
 
     @Bean
+    @ConditionalOnRequestedDependency("native")
     @ConditionalOnBuildSystem(MavenBuildSystem.ID)
     public SpringCloudAzureNativeMavenBuildCustomizer springCloudAzureNativeMavenBuildCustomizer(ProjectDescription description) {
         return new SpringCloudAzureNativeMavenBuildCustomizer(description.getPlatformVersion());
     }
 
     @Bean
+    @ConditionalOnRequestedDependency("native")
     @ConditionalOnBuildSystem(GradleBuildSystem.ID)
     public SpringCloudAzureNativeGradleBuildCustomizer springCloudAzureNativeGradleBuildCustomizer(ProjectDescription description) {
         return new SpringCloudAzureNativeGradleBuildCustomizer(description.getPlatformVersion());

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
@@ -63,6 +63,6 @@ abstract class AbstractSpringCloudAzureNativeBuildCustomizer<T extends Build> im
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE - 10;
+        return Ordered.LOWEST_PRECEDENCE - 20;
     }
 }

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.azure.spring.initializr.extension.dependency.springazure;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.generator.version.VersionProperty;
+import io.spring.initializr.generator.version.VersionReference;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.Ordered;
+
+import static com.azure.spring.initializr.extension.dependency.springazure.SpringCloudAzureNativeConfigurationVersionResolver.resolve;
+import static io.spring.initializr.generator.buildsystem.Dependency.withCoordinates;
+
+/**
+ * An abstract {@link BuildCustomizer} class that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" when relevant Spring Cloud Azure
+ * library and Spring Native are selected.
+ *
+ */
+abstract class AbstractSpringCloudAzureNativeBuildCustomizer<T extends Build> implements BuildCustomizer<T>, Ordered {
+
+    private static final Log logger = LogFactory.getLog(AbstractSpringCloudAzureNativeBuildCustomizer.class);
+
+    private final Version platformVersion;
+    private final SpringCloudAzureNativeConfigurationSupportValidator<T> supportValidator;
+
+    public AbstractSpringCloudAzureNativeBuildCustomizer(Version platformVersion) {
+        this.platformVersion = platformVersion;
+        this.supportValidator = new SpringCloudAzureNativeConfigurationSupportValidator<T>();
+    }
+
+    @Override
+	public void customize(T build) {
+        logger.info("Spring Cloud Azure Native customizer.");
+        if (supportValidator.unSupport(build)) {
+            return;
+        }
+
+        Dependency selected = build.dependencies().items()
+                                   .filter(u -> u.getGroupId().equals("com.azure.spring"))
+                                   .findAny()
+                                   .get();
+        logger.info("Select spring.cloud-azure.version: " + selected.getVersion() + ".");
+        Dependency.Builder<?> builder = withCoordinates("com.azure.spring", "spring-cloud-azure-native-configuration");
+        String azureNativeVersion = resolve(platformVersion.toString());
+        build.properties()
+             .version(VersionProperty.of("spring-cloud-azure-native-configuration.version"), azureNativeVersion);
+        build.dependencies()
+             .add("azure-native-configuration",
+                 builder.version(VersionReference.ofProperty("spring-cloud-azure-native-configuration.version")));
+	}
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 10;
+    }
+}

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
@@ -32,7 +32,6 @@ import static io.spring.initializr.generator.buildsystem.Dependency.withCoordina
 /**
  * An abstract {@link BuildCustomizer} class that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" when relevant Spring Cloud Azure
  * library and Spring Native are selected.
- *
  */
 abstract class AbstractSpringCloudAzureNativeBuildCustomizer<T extends Build> implements BuildCustomizer<T>, Ordered {
 
@@ -48,23 +47,18 @@ abstract class AbstractSpringCloudAzureNativeBuildCustomizer<T extends Build> im
 
     @Override
 	public void customize(T build) {
-        logger.info("Spring Cloud Azure Native customizer.");
         if (supportValidator.unSupport(build)) {
+            logger.debug("Spring Cloud Azure coordinates do not support Spring Native yet.");
             return;
         }
 
-        Dependency selected = build.dependencies().items()
-                                   .filter(u -> u.getGroupId().equals("com.azure.spring"))
-                                   .findAny()
-                                   .get();
-        logger.info("Select spring.cloud-azure.version: " + selected.getVersion() + ".");
         Dependency.Builder<?> builder = withCoordinates("com.azure.spring", "spring-cloud-azure-native-configuration");
         String azureNativeVersion = resolve(platformVersion.toString());
         build.properties()
              .version(VersionProperty.of("spring-cloud-azure-native-configuration.version"), azureNativeVersion);
         build.dependencies()
-             .add("azure-native-configuration",
-                 builder.version(VersionReference.ofProperty("spring-cloud-azure-native-configuration.version")));
+                .add("azure-native-configuration",
+                    builder.version(VersionReference.ofProperty("spring-cloud-azure-native-configuration.version")));
 	}
 
     @Override

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/AbstractSpringCloudAzureNativeBuildCustomizer.java
@@ -63,6 +63,6 @@ abstract class AbstractSpringCloudAzureNativeBuildCustomizer<T extends Build> im
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE - 20;
+        return Ordered.LOWEST_PRECEDENCE - 9;
     }
 }

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationSupportValidator.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationSupportValidator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.azure.spring.initializr.extension.dependency.springazure;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Validate that Spring Cloud Azure coordinates support Spring Native.
+ *
+ */
+class SpringCloudAzureNativeConfigurationSupportValidator<T extends Build> {
+
+    private static final Log logger = LogFactory.getLog(SpringCloudAzureNativeConfigurationSupportValidator.class);
+
+    /**
+     * Supported Spring Native coordinates set.
+     */
+    private static final Set<String> SUPPORTED_NATIVE_COORDINATES_SET;
+
+    static {
+        Set<String> supported = new HashSet<>();
+        supported.add("com.azure.spring:spring-cloud-azure-starter-appconfiguration");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-eventhubs");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-keyvault-certificates");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-keyvault-secrets");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-storage-blob");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-storage-file-share");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-storage-queue");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-integration-eventhubs");
+        supported.add("com.azure.spring:spring-cloud-azure-starter-integration-storage-queue");
+        SUPPORTED_NATIVE_COORDINATES_SET = Collections.unmodifiableSet(supported);
+    }
+
+    boolean support(T build) {
+        if (!build.dependencies().items().anyMatch(u -> u.getGroupId().equals("com.azure.spring"))) {
+            return false;
+        }
+
+        if (build instanceof MavenBuild){
+            MavenBuild mavenBuild = (MavenBuild) build;
+            if (!mavenBuild.dependencies().has("native")) {
+                return false;
+            }
+        } else if (build instanceof GradleBuild) {
+            GradleBuild gradleBuild = (GradleBuild) build;
+            if (!gradleBuild.plugins().has("org.springframework.experimental.aot")) {
+                return false;
+            }
+        } else {
+            logger.info("Not supported '" + build.getClass().getName() + "'.");
+            return false;
+        }
+
+        return retainSupportCoordinates(build);
+    }
+
+    boolean unSupport(T build) {
+        return !support(build);
+    }
+
+    private boolean retainSupportCoordinates(T build) {
+        Set<String> selected = build.dependencies()
+                                    .items()
+                                    .map(d -> d.getGroupId() + ":" + d.getArtifactId())
+                                    .collect(Collectors.toSet());
+        selected.retainAll(SUPPORTED_NATIVE_COORDINATES_SET);
+        return selected.size() > 0;
+    }
+}

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationSupportValidator.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationSupportValidator.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 
 /**
  * Validate that Spring Cloud Azure coordinates support Spring Native.
- *
  */
 class SpringCloudAzureNativeConfigurationSupportValidator<T extends Build> {
 
@@ -70,7 +69,7 @@ class SpringCloudAzureNativeConfigurationSupportValidator<T extends Build> {
                 return false;
             }
         } else {
-            logger.info("Not supported '" + build.getClass().getName() + "'.");
+            logger.info("Not supported '" + build.getClass().getName() + "' build implementation.");
             return false;
         }
 

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationVersionResolver.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationVersionResolver.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 /**
  * Resolve the Spring Cloud Azure Native Configuration version to use based on the Spring Boot version.
- *
  */
 abstract class SpringCloudAzureNativeConfigurationVersionResolver {
 
@@ -34,8 +33,11 @@ abstract class SpringCloudAzureNativeConfigurationVersionResolver {
 
 	static String resolve(String springBootVersion) {
 		Version nativeVersion = VersionParser.DEFAULT.parse(springBootVersion);
-		return ranges.stream().filter((range) -> range.match(nativeVersion)).findFirst()
-                     .map(NativeConfigurationRange::getVersion).orElse(null);
+		return ranges.stream()
+                     .filter((range) -> range.match(nativeVersion))
+                     .findFirst()
+                     .map(NativeConfigurationRange::getVersion)
+                     .orElse(null);
 	}
 
 	private static class NativeConfigurationRange {

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationVersionResolver.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeConfigurationVersionResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.azure.spring.initializr.extension.dependency.springazure;
+
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.generator.version.VersionParser;
+import io.spring.initializr.generator.version.VersionRange;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Resolve the Spring Cloud Azure Native Configuration version to use based on the Spring Boot version.
+ *
+ */
+abstract class SpringCloudAzureNativeConfigurationVersionResolver {
+
+	private static final List<NativeConfigurationRange> ranges = Arrays.asList(
+        new NativeConfigurationRange("[2.6.4, 2.6.7)", "4.0.0-beta.1"));
+
+	static String resolve(String springBootVersion) {
+		Version nativeVersion = VersionParser.DEFAULT.parse(springBootVersion);
+		return ranges.stream().filter((range) -> range.match(nativeVersion)).findFirst()
+                     .map(NativeConfigurationRange::getVersion).orElse(null);
+	}
+
+	private static class NativeConfigurationRange {
+
+		private final VersionRange range;
+
+		private final String version;
+
+        NativeConfigurationRange(String range, String version) {
+			this.range = parseRange(range);
+			this.version = version;
+		}
+
+		String getVersion() {
+			return this.version;
+		}
+
+		private static VersionRange parseRange(String s) {
+			return VersionParser.DEFAULT.parseRange(s);
+		}
+
+		boolean match(Version version) {
+			return this.range.match(version);
+		}
+
+	}
+
+}

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeGradleBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeGradleBuildCustomizer.java
@@ -21,8 +21,8 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.version.Version;
 
 /**
- * A Gradle {@link BuildCustomizer} that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" when relevant Spring Cloud Azure
- * library and Spring Native are selected.
+ * A Gradle {@link BuildCustomizer} that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" dependency when the relevant Spring Cloud Azure
+ * library and Spring Native dependency are selected.
  */
 public class SpringCloudAzureNativeGradleBuildCustomizer extends AbstractSpringCloudAzureNativeBuildCustomizer<GradleBuild> {
 

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeGradleBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeGradleBuildCustomizer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.azure.spring.initializr.extension.dependency.springazure;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.version.Version;
+
+/**
+ * A Gradle {@link BuildCustomizer} that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" when relevant Spring Cloud Azure
+ * library and Spring Native are selected.
+ *
+ */
+public class SpringCloudAzureNativeGradleBuildCustomizer extends AbstractSpringCloudAzureNativeBuildCustomizer<GradleBuild> {
+
+    public SpringCloudAzureNativeGradleBuildCustomizer(Version platformVersion) {
+        super(platformVersion);
+    }
+}

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeGradleBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeGradleBuildCustomizer.java
@@ -23,7 +23,6 @@ import io.spring.initializr.generator.version.Version;
 /**
  * A Gradle {@link BuildCustomizer} that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" when relevant Spring Cloud Azure
  * library and Spring Native are selected.
- *
  */
 public class SpringCloudAzureNativeGradleBuildCustomizer extends AbstractSpringCloudAzureNativeBuildCustomizer<GradleBuild> {
 

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeMavenBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeMavenBuildCustomizer.java
@@ -23,8 +23,6 @@ import io.spring.initializr.generator.version.Version;
 /**
  * A Maven {@link BuildCustomizer} that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" when relevant Spring Cloud Azure
  * library and Spring Native are selected.
- *
- *
  */
 public class SpringCloudAzureNativeMavenBuildCustomizer extends AbstractSpringCloudAzureNativeBuildCustomizer<MavenBuild> {
 

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeMavenBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringCloudAzureNativeMavenBuildCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.azure.spring.initializr.extension.dependency.springazure;
+
+import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.version.Version;
+
+/**
+ * A Maven {@link BuildCustomizer} that automatically adds "com.azure.spring:spring-cloud-azure-native-configuration" when relevant Spring Cloud Azure
+ * library and Spring Native are selected.
+ *
+ *
+ */
+public class SpringCloudAzureNativeMavenBuildCustomizer extends AbstractSpringCloudAzureNativeBuildCustomizer<MavenBuild> {
+
+    public SpringCloudAzureNativeMavenBuildCustomizer(Version platformVersion) {
+        super(platformVersion);
+    }
+}

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -281,6 +281,25 @@ initializr:
             - rel: reference
               href: https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/
               description: Spring Native Reference Guide
+        - name: Spring Cloud Azure Native Configuration
+          id: azure-native-configuration
+          compatibilityRange: "[2.6.3,2.6.7)"
+          groupId: com.azure.spring
+          artifactId: spring-cloud-azure-native-configuration
+          description: Beta support for compiling Spring Cloud Azure applications to native executables based on Spring Native.
+          facets:
+            - native
+          starter: false
+          mappings:
+            - compatibilityRange: "[2.6.3,2.6.7)"
+              version: 4.0.0-beta.1
+          links:
+            - rel: reference
+              href: https://microsoft.github.io/spring-cloud-azure/current/reference/html/index.html#spring-native-support
+              description: Spring Cloud Azure Native Support Reference Guide
+            - rel: guide
+              href: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/main/spring-native/storage-blob
+              description: Build a executable with Azure Storage Blob
         - name: Spring Boot DevTools
           id: devtools
           groupId: org.springframework.boot


### PR DESCRIPTION
The artifact id `spring-cloud-azure-native-configuration` will be added automatically when there's any Spring Cloud Azure coordinate that supports Spring Native.