### PR TITLE
Fix bug: Messaging based scenario not works as expected.

### DIFF
--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureDefaultBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureDefaultBuildCustomizer.java
@@ -31,8 +31,7 @@ public class SpringAzureDefaultBuildCustomizer implements BuildCustomizer<Build>
 	public void customize(Build build) {
 		if (build.dependencies().items().anyMatch(u -> u.getGroupId().equals("com.azure.spring"))
 				&& !build.dependencies().items().anyMatch(u -> u.getArtifactId().equals("spring-cloud-azure-starter"))) {
-			build.dependencies().add("spring-cloud-azure-starter",
-					Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter"));
+			build.dependencies().add("azure-support");
 		}
 	}
 

--- a/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
+++ b/initializr-extension/src/main/java/com/azure/spring/initializr/extension/dependency/springazure/SpringAzureMessagingBuildCustomizer.java
@@ -41,41 +41,44 @@ public class SpringAzureMessagingBuildCustomizer implements BuildCustomizer<Buil
 
     @Override
     public void customize(Build build) {
-        customizeIntegrationDependency(build);
-        customizeCloudStreamDependency(build);
+        customizeServiceBus(build);
+        customizeEventHubs(build);
+        customizeStorageQueue(build);
     }
 
-    private void customizeCloudStreamDependency(Build build) {
-        if (build.dependencies().has(CLOUD_STREAM_DEPENDENCY_ID)) {
-            if (build.dependencies().has(AZURE_EVENT_HUBS_DEPENDENCY_ID)) {
-                build.dependencies().add("spring-cloud-azure-stream-binder-eventhubs",
-                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-stream-binder-eventhubs"));
-                build.dependencies().remove(AZURE_EVENT_HUBS_DEPENDENCY_ID);
-            }
-
-            if (build.dependencies().has(AZURE_SERVICE_BUS_DEPENDENCY_ID)) {
+    private void customizeServiceBus(Build build) {
+        if (build.dependencies().has(AZURE_SERVICE_BUS_DEPENDENCY_ID)) {
+            if (build.dependencies().has(CLOUD_STREAM_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-stream-binder-servicebus",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-stream-binder-servicebus"));
+                build.dependencies().remove(AZURE_SERVICE_BUS_DEPENDENCY_ID);
+            }
+            if (build.dependencies().has(INTEGRATION_DEPENDENCY_ID)) {
+                build.dependencies().add("spring-cloud-azure-starter-integration-servicebus",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-servicebus"));
                 build.dependencies().remove(AZURE_SERVICE_BUS_DEPENDENCY_ID);
             }
         }
     }
 
-    private void customizeIntegrationDependency(Build build) {
-        if (build.dependencies().has(INTEGRATION_DEPENDENCY_ID)) {
-            if (build.dependencies().has(AZURE_EVENT_HUBS_DEPENDENCY_ID)) {
+    private void customizeEventHubs(Build build) {
+        if (build.dependencies().has(AZURE_EVENT_HUBS_DEPENDENCY_ID)) {
+            if (build.dependencies().has(CLOUD_STREAM_DEPENDENCY_ID)) {
+                build.dependencies().add("spring-cloud-azure-stream-binder-eventhubs",
+                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-stream-binder-eventhubs"));
+                build.dependencies().remove(AZURE_EVENT_HUBS_DEPENDENCY_ID);
+            }
+            if (build.dependencies().has(INTEGRATION_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-starter-integration-eventhubs",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-eventhubs"));
                 build.dependencies().remove(AZURE_EVENT_HUBS_DEPENDENCY_ID);
             }
+        }
+    }
 
-            if (build.dependencies().has(AZURE_SERVICE_BUS_DEPENDENCY_ID)) {
-                build.dependencies().add("spring-cloud-azure-starter-integration-servicebus",
-                        Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-servicebus"));
-                build.dependencies().remove(AZURE_SERVICE_BUS_DEPENDENCY_ID);
-            }
-
-            if (build.dependencies().has(AZURE_STORAGE_QUEUE_DEPENDENCY_ID)) {
+    private void customizeStorageQueue(Build build) {
+        if (build.dependencies().has(AZURE_STORAGE_QUEUE_DEPENDENCY_ID)) {
+            if (build.dependencies().has(INTEGRATION_DEPENDENCY_ID)) {
                 build.dependencies().add("spring-cloud-azure-starter-integration-storage-queue",
                         Dependency.withCoordinates("com.azure.spring", "spring-cloud-azure-starter-integration-storage-queue"));
                 build.dependencies().remove(AZURE_STORAGE_QUEUE_DEPENDENCY_ID);


### PR DESCRIPTION
Fix bug: when cloud stream, spring integration, and servicebus are selected
1. Dependency `spring-cloud-azure-dependencies` is missing which should not. 
2. Only `spring-cloud-azure-stream-binder-servicebus` or `spring-cloud-azure-starter-integration-servicebus` is imported.
    - The expected behavior is both `spring-cloud-azure-stream-binder-servicebus` and `spring-cloud-azure-starter-integration-servicebus` should be imported.